### PR TITLE
Non existant sensor file fix

### DIFF
--- a/lib.py
+++ b/lib.py
@@ -18,7 +18,9 @@ def _read_data_from_file(full_file_path):
     return file_data
 
 
-def get_temp_from_sensor(sensor_id=None, output_file_dir=None, output_filename="w1_slave"):
+def get_temp_from_sensor(sensor_id=None,
+                         output_file_dir=None,
+                         output_filename="w1_slave"):
     """Gets the tempearture data from sensor, designed for DS18B20.
 
     :param sensor_id: unique id of the sensor, used to locate its output file if output_file_dir is not provided
@@ -27,12 +29,12 @@ def get_temp_from_sensor(sensor_id=None, output_file_dir=None, output_filename="
     """
 
     file_location = output_file_dir if output_file_dir is not None else f"/w1_bus_master1/{sensor_id}/"
-    file_data = _read_data_from_file(full_file_path=f"{file_location}{output_filename}")
-
     try:
+        file_data = _read_data_from_file(
+            full_file_path=f"{file_location}{output_filename}")
         temp_data = re.search('t=[0-9]+', file_data)[0]
         celcius = float(temp_data[2:]) / 1000
-    except TypeError:
+    except (TypeError, FileNotFoundError):
         celcius = -1  # temp data could not be read from the output file
 
     return celcius
@@ -49,15 +51,17 @@ def get_active_sensor_information(sensor_file_path):
 
     f_lines = _read_data_from_file(sensor_file_path).split("\n")
     if len(f_lines) <= 1:
-        raise ValueError("A valid sensor_info file with information is missing. "
-                         "Please populate one by following the example")
+        raise ValueError(
+            "A valid sensor_info file with information is missing. "
+            "Please populate one by following the example")
 
     for data_line in f_lines[1:]:
         if data_line != "":
             try:
                 lst_sensors.append(sensor._make(data_line.split(",")))
             except TypeError:
-                raise ValueError("Sensor file doesnt have correctly formated information. "
-                                 "Please populate one by following the example")
+                raise ValueError(
+                    "Sensor file doesnt have correctly formated information. "
+                    "Please populate one by following the example")
 
     return lst_sensors

--- a/main.py
+++ b/main.py
@@ -1,12 +1,16 @@
 from os import getenv
 from time import sleep
+
+from influx_measurement import InfluxMeasurement
 from influxdb import InfluxDBClient
 from influxdb.exceptions import InfluxDBClientError
-from lib import get_temp_from_sensor, get_active_sensor_information
-from influx_measurement import InfluxMeasurement
+from lib import get_active_sensor_information, get_temp_from_sensor
 
 
-def setup_db_for_use(host, port, db_name='firefly', retention_duration='1h',
+def setup_db_for_use(host,
+                     port,
+                     db_name='firefly',
+                     retention_duration='1h',
                      retention_policy_name="default_firefly_retention"):
     """
     Sets up an instance of InfluxDB to store data to.
@@ -24,11 +28,17 @@ def setup_db_for_use(host, port, db_name='firefly', retention_duration='1h',
         client.create_database(db_name)
 
     client.switch_database(db_name)
-    client.create_retention_policy(retention_policy_name, retention_duration, 1, default=True)
+    client.create_retention_policy(retention_policy_name,
+                                   retention_duration,
+                                   1,
+                                   default=True)
     return client
 
 
-def generate_a_measurement_point(item_name, sensor_name=None, sensor_id=None, sensor_output_file_dir=None,
+def generate_a_measurement_point(item_name,
+                                 sensor_name=None,
+                                 sensor_id=None,
+                                 sensor_output_file_dir=None,
                                  output_filename="w1_slave"):
     """
     Generates an InfluxDB style measurement point based on the data provided.
@@ -40,9 +50,12 @@ def generate_a_measurement_point(item_name, sensor_name=None, sensor_id=None, se
     :param output_filename: name of the sensor's output file
     :return: An InfluxDB style measurement point
     """
-    temp = get_temp_from_sensor(sensor_id=sensor_id, output_file_dir=sensor_output_file_dir,
+    temp = get_temp_from_sensor(sensor_id=sensor_id,
+                                output_file_dir=sensor_output_file_dir,
                                 output_filename=output_filename)
-    point = InfluxMeasurement(measurement_val=item_name, tag_val=sensor_name, field_val=temp).measurement_point
+    point = InfluxMeasurement(measurement_val=item_name,
+                              tag_val=sensor_name,
+                              field_val=temp).measurement_point
     return point
 
 
@@ -57,7 +70,8 @@ def write_data_to_db(client, points_information):
     try:
         client.write_points(points_information)
     except InfluxDBClientError:
-        raise InfluxDBClientError(f"error for data entry :: {points_information}")
+        raise InfluxDBClientError(
+            f"error for data entry :: {points_information}")
 
 
 def main(client, temp_sensors):
@@ -68,7 +82,8 @@ def main(client, temp_sensors):
     :param temp_sensors: All the sensors that should be read; List
     """
     for sensor in temp_sensors:
-        point = generate_a_measurement_point(sensor.item, sensor.name, sensor.id)
+        point = generate_a_measurement_point(sensor.item, sensor.name,
+                                             sensor.id)
         write_data_to_db(client, [point])
 
 

--- a/tests/test_influx_measurement.py
+++ b/tests/test_influx_measurement.py
@@ -5,13 +5,14 @@ class TestInfluxMeasurement:
     """
     Unit tests for influx_measurement.py
     """
-
     @staticmethod
     def test_generate_point():
         """Should generate a valid measurement object using the value provided"""
 
         m_val, t_val, f_val = ["mval", "tval", "fval"]
-        point = InfluxMeasurement(measurement_val=m_val, tag_val=t_val, field_val=f_val).measurement_point
+        point = InfluxMeasurement(measurement_val=m_val,
+                                  tag_val=t_val,
+                                  field_val=f_val).measurement_point
         assert point["measurement"] == m_val
         assert point["tags"]["sensor"] == t_val
         assert point["fields"]["temp"] == f_val

--- a/tests/test_lib.py
+++ b/tests/test_lib.py
@@ -11,7 +11,8 @@ class TestLib:
 
         test_file_name = "sensor_out_valid.txt"
         expected_temp_val = 29.191  # taken from the test_file
-        actual_val = lib.get_temp_from_sensor(output_file_dir=TEST_FILE_DIR, output_filename=test_file_name)
+        actual_val = lib.get_temp_from_sensor(output_file_dir=TEST_FILE_DIR,
+                                              output_filename=test_file_name)
         assert actual_val == expected_temp_val
 
     @staticmethod
@@ -20,14 +21,27 @@ class TestLib:
 
         test_file_name = "sensor_out_invalid.txt"
         expected_temp_val = -1
-        actual_val = lib.get_temp_from_sensor(output_file_dir=TEST_FILE_DIR, output_filename=test_file_name)
+        actual_val = lib.get_temp_from_sensor(output_file_dir=TEST_FILE_DIR,
+                                              output_filename=test_file_name)
+        assert actual_val == expected_temp_val
+
+    @staticmethod
+    def test_show_default_val_for_nonexistant_sensor_file():
+        """If a sensor file does not exist, then the default value of -1 should be returned"""
+
+        non_existant_test_file = "non_existant_test_file"
+        expected_temp_val = -1
+        actual_val = lib.get_temp_from_sensor(output_file_dir=TEST_FILE_DIR,
+                                              output_filename=non_existant_test_file
+                                              )
         assert actual_val == expected_temp_val
 
     @staticmethod
     def test_get_active_sensor_information_valid_info():
         """Should parse a valid sensors_info file and create data object"""
 
-        lst_sensors = lib.get_active_sensor_information(f"{TEST_FILE_DIR}sensors_info.valid")
+        lst_sensors = lib.get_active_sensor_information(
+            f"{TEST_FILE_DIR}sensors_info.valid")
         assert len(lst_sensors) == 2
         assert lst_sensors[0]._fields == ('item', 'id', 'name')
 
@@ -36,4 +50,5 @@ class TestLib:
         """Should parse a invalid sensors_info file and create data object"""
 
         with pytest.raises(ValueError):
-            lib.get_active_sensor_information(f"{TEST_FILE_DIR}sensors_info.invalid")
+            lib.get_active_sensor_information(
+                f"{TEST_FILE_DIR}sensors_info.invalid")

--- a/tests/test_lib.py
+++ b/tests/test_lib.py
@@ -31,9 +31,9 @@ class TestLib:
 
         non_existant_test_file = "non_existant_test_file"
         expected_temp_val = -1
-        actual_val = lib.get_temp_from_sensor(output_file_dir=TEST_FILE_DIR,
-                                              output_filename=non_existant_test_file
-                                              )
+        actual_val = lib.get_temp_from_sensor(
+            output_file_dir=TEST_FILE_DIR,
+            output_filename=non_existant_test_file)
         assert actual_val == expected_temp_val
 
     @staticmethod

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -6,7 +6,9 @@ import main
 class TestMain:
     """ Influxdb docker container must be running for these tests """
     target, portnum = [getenv("DBHOST", "localhost"), getenv("DBPORT", "8086")]
-    test_client = main.setup_db_for_use(host=target, port=portnum, db_name="testDB",
+    test_client = main.setup_db_for_use(host=target,
+                                        port=portnum,
+                                        db_name="testDB",
                                         retention_policy_name="testRetention")
     expected_temp_val = 29.191  # taken from sensor_out_valid.txt
 
@@ -25,16 +27,19 @@ class TestMain:
             'replicaN': 1,
             'default': True
         }
-        assert expected_retention in self.test_client.get_list_retention_policies()
+        assert expected_retention in self.test_client.get_list_retention_policies(
+        )
 
     def test_generate_a_measurement_point(self):
         """A measurement point can be created with the data specified"""
 
         item_name, sensor_name = ["itemA", "sensorA"]
 
-        result = main.generate_a_measurement_point(item_name, sensor_name=sensor_name,
-                                                   sensor_output_file_dir="tests/datafiles/",
-                                                   output_filename="sensor_out_valid.txt")
+        result = main.generate_a_measurement_point(
+            item_name,
+            sensor_name=sensor_name,
+            sensor_output_file_dir="tests/datafiles/",
+            output_filename="sensor_out_valid.txt")
         assert result["measurement"] == item_name
         assert result["tags"]["sensor"] == sensor_name
         assert result["fields"]["temp"] == self.expected_temp_val
@@ -49,13 +54,16 @@ class TestMain:
             """Get measurement points from db given a query"""
 
             try:
-                return self.test_client.query(_query).raw["series"][0]["values"]
+                return self.test_client.query(
+                    _query).raw["series"][0]["values"]
             except KeyError:
                 return []
 
-        test_point = main.generate_a_measurement_point(measurement, sensor_name=sensor_name,
-                                                       sensor_output_file_dir="tests/datafiles/",
-                                                       output_filename="sensor_out_valid.txt")
+        test_point = main.generate_a_measurement_point(
+            measurement,
+            sensor_name=sensor_name,
+            sensor_output_file_dir="tests/datafiles/",
+            output_filename="sensor_out_valid.txt")
 
         original_points_in_db = get_points(query)
         main.write_data_to_db(self.test_client, [test_point])


### PR DESCRIPTION
**Main change**: if a temp sensor file doesn't exist, it will return a default value of -1.
_reason_: sometimes a sensor gets disconnected and its output file will disappear. when this happens the program shouldn't crash and burn, but instead keep running, while displaying a default value

Other changes:   pep8 formatting 